### PR TITLE
Make GitHub detect the blk files as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+screens/blk* linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect the `screens/blk*` files as Forth.

Thanks!
